### PR TITLE
Check cookie within JS first before initializing form: bypasses WP ca…

### DIFF
--- a/lib/assets/js/verifier.js
+++ b/lib/assets/js/verifier.js
@@ -4,7 +4,10 @@ var taseavWrapper = jQuery('#taseav-age-verify');
 var verifier = new EavVerifier();
 
 /**
- * Checks the cookie value and only initiates form if not overAge
+ * Original JavaScript code by Chirp Internet: www.chirp.com.au
+ * Please acknowledge use of this code by including this header.
+ *
+ * Checks the cookies for a named value
  *
  * @param name
  */
@@ -18,6 +21,8 @@ function getCookie(name){
  * Gets the verifier form when the site loads
  */
 jQuery(document).ready(function(){
+
+  // Only init form if cookie is not 'overAge'
   var cookie = getCookie('eav_age');
   if ( cookie !== 'overAge' ) {
     verifier.getForm();

--- a/lib/assets/js/verifier.js
+++ b/lib/assets/js/verifier.js
@@ -4,10 +4,24 @@ var taseavWrapper = jQuery('#taseav-age-verify');
 var verifier = new EavVerifier();
 
 /**
+ * Checks the cookie value and only initiates form if not overAge
+ *
+ * @param name
+ */
+function getCookie(name){
+  var re = new RegExp(name + "=([^;]+)");
+  var value = re.exec(document.cookie);
+  return (value != null) ? unescape(value[1]) : null;
+}
+
+/**
  * Gets the verifier form when the site loads
  */
 jQuery(document).ready(function(){
-  verifier.getForm();
+  var cookie = getCookie('eav_age');
+  if ( cookie !== 'overAge' ) {
+    verifier.getForm();
+  }
 });
 
 /**


### PR DESCRIPTION
_Check cookie within JS first before initializing form: bypasses WP caching issues_

This is probably not an ideal solution but I needed something today for a client whose Pantheon Cache plugin was causing problems. First suggestion would be to change the magic cookie name string. Tested on client site, it does work.

references issue #93 