### PR TITLE
Simplify cache buster

### DIFF
--- a/easy-age-verifier.php
+++ b/easy-age-verifier.php
@@ -61,6 +61,10 @@ if(!class_exists('eav')){
       define('EAV_TEMPLATES_PATH', EAV_ASSETS_PATH.'templates/');
       define('EAV_TEXT_DOMAIN', 'easyageverifier');
       define('EAV_PREFIX', 'eav');
+
+      $version = get_plugin_data(__FILE__,false,false);
+      $version = $version['Version'];
+      define('EAV_VERSION', $version);
     }
 
     /**

--- a/easy-age-verifier.php
+++ b/easy-age-verifier.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Easy Age Verifier
 Description: Easy Age Verifier makes it easy for websites to confirm their website visitors are of legal age.
-Version:     2.10
+Version:     2.1.1
 Author:      Alex Standiford (Fill Your Taproom)
 Author URI:  http://www.fillyourtaproom.com
 License:     GPL3

--- a/lib/app/verifier.php
+++ b/lib/app/verifier.php
@@ -152,13 +152,13 @@ class verifier{
     //Calls jQuery beforehand as verify-age depends on it
     wp_enqueue_script('jquery');
     //Registers the Age Verification Script
-    wp_register_script('verify-age.js', EAV_ASSETS_URL.'js/verifier.js', array(), '2.10');
+    wp_register_script('verify-age.js', EAV_ASSETS_URL.'js/verifier.js', array(), EAV_VERSION);
     //Adds PHP Variables to the script as an object
     wp_localize_script('verify-age.js', 'eav', $this->passData());
     //Calls Age Verification Script
     wp_enqueue_script('verify-age.js', array());
     //Age Verification Style
-    wp_enqueue_style('verify-age.css', EAV_ASSETS_URL.'/css/verifier.css', array(), '2.10');
+    wp_enqueue_style('verify-age.css', EAV_ASSETS_URL.'/css/verifier.css', array(), EAV_VERSION);
   }
 
   /**

--- a/lib/config/menu.php
+++ b/lib/config/menu.php
@@ -73,9 +73,9 @@ class menu{
   }
 
   public function getDebugger(){
-    wp_enqueue_style('eav-admin',EAV_ASSETS_URL.'css/admin.css','2.10');
+    wp_enqueue_style('eav-admin',EAV_ASSETS_URL.'css/admin.css',EAV_VERSION);
 
-    wp_register_script('eav-admin',EAV_ASSETS_URL.'js/admin.js',['jquery'],'2.10');
+    wp_register_script('eav-admin',EAV_ASSETS_URL.'js/admin.js',['jquery'],EAV_VERSION);
     wp_localize_script('eav-admin','eavAdmin',['nonce' => wp_create_nonce('wp_rest'),'debugModeUrl' => get_rest_url(null,'/easy-age-verifier/v1/toggle-debug-mode')]);
     wp_enqueue_script('eav-admin');
 


### PR DESCRIPTION
Simplified the logic of the cache buster to use an `EAV_VERSION` constant, which is connected directly to the plugin version.

I kept forgetting to update my script version tag, which caused headaches during deployment, so I decided to automate it instead.